### PR TITLE
Add a healthcheck framework

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,19 +46,20 @@ PATH
       sinatra-activerecord (~> 2.0)
       sinatra-contrib (~> 1.4)
       sinatra-flash (~> 0.3)
+      sinatra-health-check (~> 0.2.0)
       warden (~> 1.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.6)
-      activesupport (= 4.2.6)
+    activemodel (4.2.7.1)
+      activesupport (= 4.2.7.1)
       builder (~> 3.1)
-    activerecord (4.2.6)
-      activemodel (= 4.2.6)
-      activesupport (= 4.2.6)
+    activerecord (4.2.7.1)
+      activemodel (= 4.2.7.1)
+      activesupport (= 4.2.7.1)
       arel (~> 6.0)
-    activesupport (4.2.6)
+    activesupport (4.2.7.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -158,7 +159,7 @@ GEM
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
-    sinatra-activerecord (2.0.9)
+    sinatra-activerecord (2.0.10)
       activerecord (>= 3.2)
       sinatra (~> 1.0)
     sinatra-contrib (1.4.7)
@@ -170,6 +171,7 @@ GEM
       tilt (>= 1.3, < 3)
     sinatra-flash (0.3.0)
       sinatra (>= 1.0.0)
+    sinatra-health-check (0.2.0)
     slop (3.6.0)
     spoon (0.0.4)
       ffi

--- a/app/cyclid_ui.rb
+++ b/app/cyclid_ui.rb
@@ -118,6 +118,7 @@ module Cyclid
       use Controllers::Auth
       use Controllers::Organization
       use Controllers::User
+      use Controllers::Health
     end
   end
 end

--- a/app/cyclid_ui/controllers/health.rb
+++ b/app/cyclid_ui/controllers/health.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+# Copyright 2016 Liqwyd Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require 'sinatra-health-check'
+require 'memcached'
+
+# Top level module for all of the core Cyclid code.
+module Cyclid
+  module UI
+    module Controllers
+      # Controller for all Health related API endpoints
+      class Health < Base
+        def initialize(_app)
+          super
+          @checker = SinatraHealthCheck::Checker.new(logger: Cyclid.logger,
+                                                     timeout: 0)
+
+          # Add internal health checks
+          @checker.systems[:memcache] = Cyclid::UI::Health::Memcache
+        end
+
+        # Return either 200 (healthy) or 503 (unhealthy) based on the status of
+        # the healthchecks. This is intended to be used by things like load
+        # balancers and active monitors.
+        get '/health/status' do
+          @checker.healthy? ? 200 : 503
+        end
+
+        # Return verbose information on the status of the individual checks;
+        # note that this method always returns 200 with a message body, so it is
+        # not suitable for general health checks unless the caller intends to
+        # parse the message body for the health status.
+        get '/health/info' do
+          @checker.status.to_json
+        end
+      end
+    end
+
+    # Healthchecks
+    module Health
+      module Memcache
+        # Check if Memcache is available
+        def self.status
+          connected = begin
+                        memcache = Memcached.new(Cyclid.config.memcached)
+                        memcache.stats
+                        true
+                      rescue Memcached::SomeErrorsWereReported
+                        false
+                      end
+
+          if connected
+            SinatraHealthCheck::Status.new(:ok, 'memcache connection is okay')
+          else
+            SinatraHealthCheck::Status.new(:warning, 'memcache is not available')
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/cyclid_ui/controllers/health.rb
+++ b/app/cyclid_ui/controllers/health.rb
@@ -49,6 +49,7 @@ module Cyclid
 
     # Healthchecks
     module Health
+      # Internal Memcache connection health check
       module Memcache
         # Check if Memcache is available
         def self.status

--- a/cyclid-ui.gemspec
+++ b/cyclid-ui.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('warden', '~> 1.2')
   s.add_runtime_dependency('activerecord', '~> 4.2')
   s.add_runtime_dependency('sinatra-activerecord', '~> 2.0')
+  s.add_runtime_dependency('sinatra-health-check', '~> 0.2.0')
   s.add_runtime_dependency('sinatra-flash', '~> 0.3')
   s.add_runtime_dependency('mustache', '~> 1.0')
   s.add_runtime_dependency('mustache-sinatra', '~> 1.0')

--- a/spec/controllers/health_spec.rb
+++ b/spec/controllers/health_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'json'
+
+describe 'a health check' do
+  include Rack::Test::Methods
+
+  context 'when the application is healthy' do
+    before do
+      allow_any_instance_of(SinatraHealthCheck::Checker).to receive(:healthy?).and_return true
+    end
+
+    describe 'GET /health/status' do
+      it 'returns a 200 response' do
+        get '/health/status'
+        expect(last_response.status).to eq(200)
+      end
+    end
+
+    describe 'GET /health/info' do
+      it 'returns a JSON response' do
+        get '/health/info'
+        expect(last_response.status).to eq(200)
+
+        res = JSON.parse(last_response.body)
+        expect(res['status']).to eq 'OK'
+      end
+    end
+  end
+
+  context 'when the application is unhealthy' do
+    before do
+      allow_any_instance_of(SinatraHealthCheck::Checker).to receive(:healthy?).and_return false
+    end
+
+    describe 'GET /health/status' do
+      it 'returns a 503 response' do
+        get '/health/status'
+        expect(last_response.status).to eq(503)
+      end
+    end
+
+    describe 'GET /health/info' do
+      it 'returns a JSON response' do
+        dbl = double('memcache')
+        allow(dbl).to receive(:stats).and_raise Memcached::SomeErrorsWereReported
+
+        allow(Memcached).to receive(:new).and_return dbl
+
+        get '/health/info'
+        expect(last_response.status).to eq(200)
+
+        res = JSON.parse(last_response.body)
+        STDERR.puts "res=#{res.inspect}"
+        expect(res['status']).to eq 'WARNING'
+      end
+    end
+  end
+end
+
+describe Cyclid::UI::Health::Memcache do
+  describe '#status' do
+    let :memcache do
+      double('memcache')
+    end
+
+    before do
+      allow(Memcached).to receive(:new).and_return memcache
+    end
+
+    it 'returns an OK response when memcache is connected' do
+      allow(memcache).to receive(:stats).and_return(true)
+
+      expect(status = Cyclid::UI::Health::Memcache.status).to be_a(SinatraHealthCheck::Status)
+      expect(status.level).to eq(:ok)
+      expect(status.message).to eq('memcache connection is okay')
+    end
+
+    it 'returns an error response when memcache is not connected' do
+      allow(memcache).to receive(:stats).and_raise Memcached::SomeErrorsWereReported
+
+      expect(status = Cyclid::UI::Health::Memcache.status).to be_a(SinatraHealthCheck::Status)
+      expect(status.level).to eq(:warning)
+      expect(status.message).to eq('memcache is not available')
+    end
+  end
+end
+
+describe Cyclid::UI::Health::API do
+  describe '#status' do
+    let :tilapia do
+      double('tilapia')
+    end
+
+    before do
+      allow(Cyclid::Client::Tilapia).to receive(:new).and_return tilapia
+    end
+
+    it 'returns an OK response when the API is connected' do
+      allow(tilapia).to receive(:health_ping).and_return true
+
+      expect(status = Cyclid::UI::Health::API.status).to be_a(SinatraHealthCheck::Status)
+      expect(status.level).to eq(:ok)
+      expect(status.message).to eq('API connection is okay')
+    end
+
+    it 'returns an error response when the API is not connected' do
+      allow(tilapia).to receive(:health_ping).and_return false
+
+      expect(status = Cyclid::UI::Health::API.status).to be_a(SinatraHealthCheck::Status)
+      expect(status.level).to eq(:error)
+      expect(status.message).to eq('API is not available')
+    end
+  end
+end


### PR DESCRIPTION
Add sinatra-health-check and provide the /health/status & /health/info
endpoints.
Provide a health check for Memcache.
Provide an API healthcheck on top of the client health_ping method.