### PR TITLE
Fix downloadable configurations

### DIFF
--- a/public/js/user.js
+++ b/public/js/user.js
@@ -41,7 +41,7 @@ function user_update_details(user){
       config_org.click(function(e) {
         var org = $(this).data('org');
 
-        var config = `server: ${gblAPIURL}\n` +
+        var config = `url: ${gblAPIURL}\n` +
                      `organization: ${org}\n` +
                      `username: ${user.username}\n` +
                      `secret: ${user.secret}\n`;


### PR DESCRIPTION
Cyclid client expects the key to be "url:" if the API is specified with a full
URL component.